### PR TITLE
Add cancel translation endpoint and tests

### DIFF
--- a/cancel_translation/__init__.py
+++ b/cancel_translation/__init__.py
@@ -1,0 +1,40 @@
+"""
+Annule une traduction en cours
+Route: DELETE /api/cancel_translation/{translation_id}
+"""
+
+import azure.functions as func
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+from shared.utils.response_helper import create_response, create_error_response
+from shared.services.translation_handler import TranslationHandler
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    """Annule une traduction en cours"""
+    try:
+        translation_id = req.route_params.get('translation_id') or req.params.get('translation_id')
+
+        if not translation_id:
+            return create_error_response("ID de traduction manquant", 400)
+        if not translation_id.strip():
+            return create_error_response("ID de traduction vide", 400)
+
+        logger.info(f"🛑 Annulation demandée pour: {translation_id}")
+
+        handler = TranslationHandler()
+        result = handler.cancel_translation(translation_id)
+
+        if result.get("success"):
+            data = {"translation_id": translation_id, "message": result.get("message")}
+            return create_response(data, 200)
+        else:
+            message = result.get("message", "Erreur d'annulation")
+            status_code = 404 if "introuvable" in message.lower() else 500
+            return create_error_response(message, status_code)
+
+    except Exception as e:
+        logger.error(f"❌ Erreur lors de l'annulation: {str(e)}")
+        return create_error_response(f"Erreur interne: {str(e)}", 500)

--- a/cancel_translation/function.json
+++ b/cancel_translation/function.json
@@ -1,0 +1,20 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "delete"
+      ],
+      "route": "cancel_translation/{translation_id}"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/tests/test_cancel_translation.py
+++ b/tests/test_cancel_translation.py
@@ -1,0 +1,46 @@
+import json
+import importlib
+import azure.functions as func
+from unittest.mock import patch
+
+cancel_translation = importlib.import_module("cancel_translation.__init__")
+
+
+def make_request(route_id=None, query_id=None, method='DELETE'):
+    return func.HttpRequest(
+        method=method,
+        url='/api/cancel_translation',
+        headers={},
+        params={} if query_id is None else {'translation_id': query_id},
+        route_params={} if route_id is None else {'translation_id': route_id},
+        body=b''
+    )
+
+
+@patch('cancel_translation.__init__.TranslationHandler')
+def test_cancel_translation_success(handler_cls):
+    handler = handler_cls.return_value
+    handler.cancel_translation.return_value = {
+        'success': True,
+        'message': 'Traduction annulée'
+    }
+
+    req = make_request(route_id='123')
+    resp = cancel_translation.main(req)
+
+    assert resp.status_code == 200
+    body = json.loads(resp.get_body())
+    assert body['data']['translation_id'] == '123'
+    assert body['data']['message'] == 'Traduction annulée'
+    handler.cancel_translation.assert_called_once_with('123')
+
+
+@patch('cancel_translation.__init__.TranslationHandler')
+def test_cancel_translation_missing_id(handler_cls):
+    req = make_request()
+    resp = cancel_translation.main(req)
+
+    assert resp.status_code == 400
+    body = json.loads(resp.get_body())
+    assert body['success'] is False
+    assert 'ID de traduction manquant' in body['error']['message']


### PR DESCRIPTION
## Summary
- add cancel_translation function to abort in-progress translations
- expose DELETE /api/cancel_translation/{translation_id} route
- cover cancellation logic with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890e3274450832890fdc284b0a8ef22